### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ publicly hosted version thereof. In particular:
 
 It is possible to run FemtoCleaner locally (to fix, for example, deprecations in a private repository).
 
-Install `FemtoCleaner` using
+Install `FemtoCleaner` (currently working on Julia v0.6.x only) using
 
 ```jl
 Pkg.clone("https://github.com/Keno/AbstractTrees.jl")


### PR DESCRIPTION
Makes it clear that FemtoCleaner should (at least for the moment) be installed on v0.6. (dependencies fail with various errors when trying to compile on 0.7.)